### PR TITLE
Add tokens auto price floating approximation display

### DIFF
--- a/src/features/tokens/token/Token.jsx
+++ b/src/features/tokens/token/Token.jsx
@@ -1,10 +1,11 @@
 import { makeStyles } from "@material-ui/core";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { useHistory, useParams } from "react-router-dom";
 import ButtonGroup from "../../../components/buttonGroup/ButtonGroup";
 import Paper from "../../../components/paper/Paper";
 import { useTokens } from "../../../contexts/TokensProvider";
 import {
+  detectBestDecimalsDisplay,
   formatDate,
   formatDateHours,
   formateNumberPrice,
@@ -117,6 +118,7 @@ const Token = ({ showToast }) => {
   const [dataHover, setDataHover] = useState({ price: "0", date: "-" });
   const [liquidity, setLiquidity] = useState([]);
   const [volume, setVolume] = useState([]);
+  const priceDecimals = useRef(2);
 
   useEffect(() => {
     // get token from history state
@@ -154,6 +156,7 @@ const Token = ({ showToast }) => {
         let priceData = results[0];
         let liquidityData = results[1];
         let volumeData = results[2];
+        priceDecimals.current = priceData.length > 0 ? detectBestDecimalsDisplay(priceData[0].open) : 2;;
         setLiquidity(liquidityData);
         setVolume(volumeData);
         let name = getName("price", "7d");
@@ -163,7 +166,7 @@ const Token = ({ showToast }) => {
           return { ...ps, [name]: priceData };
         });
         setDataHover({
-          price: formateNumberPriceDecimals(priceData[priceData.length - 1].open, 2),
+          price: formateNumberPriceDecimals(priceData[priceData.length - 1].open, priceDecimals.current),
           date: formatDateHours(new Date()),
         });
       } catch (error) {
@@ -183,7 +186,7 @@ const Token = ({ showToast }) => {
     (event, serie) => {
       if (selectTypeChart === "price") {
         if (event.time) {
-          let price = formateNumberPriceDecimals(event.seriesPrices.get(serie).close, 2);
+          let price = formateNumberPriceDecimals(event.seriesPrices.get(serie).close, priceDecimals.current);
           let currentDate = new Date(event.time * 1000);
           setDataHover({ price, date: formatDateHours(currentDate) });
         }
@@ -205,7 +208,7 @@ const Token = ({ showToast }) => {
         }
       }
     },
-    [selectTypeChart]
+    [selectTypeChart, priceDecimals]
   );
 
   const onChangeTypeChart = (value) => {
@@ -239,7 +242,7 @@ const Token = ({ showToast }) => {
           return { ...ps, [name]: chartData };
         });
         setDataHover({
-          price: formateNumberPriceDecimals(chartData[chartData.length - 1].open),
+          price: formateNumberPriceDecimals(chartData[chartData.length - 1].open, priceDecimals.current),
           date: formatDateHours(new Date()),
         });
       }
@@ -274,7 +277,7 @@ const Token = ({ showToast }) => {
     <div className={classes.tokenRoot}>
       <TokenPath token={token} />
       <TokenTitle token={token} />
-      <p className={classes.tokenPrice}>{formateNumberPriceDecimals(token.price)}</p>
+      <p className={classes.tokenPrice}>{formateNumberPriceDecimals(token.price, priceDecimals.current)}</p>
       <div className={classes.charts}>
         <Paper>
           <div className={classes.details}>
@@ -293,7 +296,7 @@ const Token = ({ showToast }) => {
             <div className={classes.detail}>
               <p className={classes.titleDetail}>Price</p>
               <p variant="body2" className={classes.dataDetail}>
-                {formateNumberPriceDecimals(token.price)}
+                {formateNumberPriceDecimals(token.price, priceDecimals.current)}
               </p>
             </div>
           </div>

--- a/src/features/tokens/token/TokenChartPrice.jsx
+++ b/src/features/tokens/token/TokenChartPrice.jsx
@@ -2,7 +2,7 @@ import { makeStyles, useMediaQuery } from "@material-ui/core";
 import { useEffect } from "react";
 import { useRef } from "react";
 import { createChart, CrosshairMode } from "lightweight-charts";
-import { float2Numbers } from "../../../helpers/helpers";
+import { detectBestDecimalsDisplay, formateNumberPriceDecimals } from "../../../helpers/helpers";
 import { ResizeObserver } from "resize-observer";
 
 const useStyles = makeStyles((theme) => {
@@ -31,6 +31,7 @@ const TokenChartPrice = ({ data, crossMove }) => {
   const serieRef = useRef(null);
   const resizeObserver = useRef(null);
   const matchXS = useMediaQuery((theme) => theme.breakpoints.down("xs"));
+  const priceDecimals = useRef(2);
 
   useEffect(() => {
     resizeObserver.current = new ResizeObserver((entries, b) => {
@@ -57,7 +58,7 @@ const TokenChartPrice = ({ data, crossMove }) => {
         },
         localization: {
           priceFormatter: (price) => {
-            return float2Numbers(price);
+            return formateNumberPriceDecimals(price, priceDecimals.current);
           },
         },
         grid: {
@@ -88,12 +89,13 @@ const TokenChartPrice = ({ data, crossMove }) => {
     return () => {
       chartRef.current.unsubscribeCrosshairMove();
     };
-  }, [crossMove]);
+  }, [crossMove, priceDecimals]);
 
   useEffect(() => {
     // When data is updated
     serieRef.current.setData(data);
     chartRef.current.timeScale().fitContent();
+    priceDecimals.current = data.length > 0 ? detectBestDecimalsDisplay(data[0].open) : 2;
   }, [data]);
 
   return (

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -29,6 +29,23 @@ export const formatDateHours = (date) => {
 }
 
 
+export const detectBestDecimalsDisplay = (price) => {
+    let decimals = 2;
+    if (price !== undefined) {
+        // Find out the number of leading floating zeros via regex
+        const priceSplit = price.toString().split('.');
+        if (priceSplit.length === 2) {
+            const leadingZeros = priceSplit[1].match(/^0+/);
+            decimals += leadingZeros ? leadingZeros[0].length + 1 : 0;
+            if (decimals === 2 && priceSplit[0] === '0') {
+                // Add one more decimal in case of 0.12 kind of price
+                decimals++;
+            }
+        }
+    }
+    return decimals;
+}
+
 export const formateNumberPriceDecimals = (price, decimals = 2) => {
     return new Intl.NumberFormat('en-US',
         {


### PR DESCRIPTION
**Description:**
This PR intends to improve the price display of assets priced under 0.10 by detecting the appropriate number of decimals to display depending on the current asset price.

**Notes:**
- This only affect the token price display, not the pool display
- This should not have any side effect since it does not modify existing helpers
- The decimals detection is only done at data loading/refresh time to avoid slowing down the UI (notably the chart hover)
- The decimals selection is quite arbitrary and can be changed according to what the Osmosis team think is best

**Example outputs:**
- 12.345678 => $12.34
- 1.2345678 => $1.23
- 0.1234567 => $0.123
- 0.0123456 => $0.0123
- 0.0012345 => $0.00123