### PR TITLE
Improve auto decimal detection and apply it to all displays

### DIFF
--- a/src/features/tokens/TokensTable.jsx
+++ b/src/features/tokens/TokensTable.jsx
@@ -2,7 +2,7 @@ import { makeStyles, Table, TableBody, TableCell, TableRow, Tooltip } from "@mat
 import { useState } from "react";
 import Image from "../../components/image/Image";
 import TablePagination from "../../components/tablePagination/TablePagination";
-import { formateNumberPrice, formateNumberPriceDecimals, formaterNumber, twoNumber } from "../../helpers/helpers";
+import { formateNumberPrice, formateNumberPriceDecimalsAuto, formaterNumber } from "../../helpers/helpers";
 import TokensHeaderTable from "./TokensHearderTable";
 
 const useStyles = makeStyles((theme) => {
@@ -208,7 +208,7 @@ const TokensTable = ({ data, textEmpty, size = "ld", sortable = true, onClickTok
         cellClasses: size === "xs" ? classes.cellsExtraSmall : classes.cells,
         classes: size === "xs" ? classes.hCellsExtraSmall : classes.hCellsLg,
         sortable: sortable,
-        transform: formateNumberPriceDecimals,
+        transform: formateNumberPriceDecimalsAuto,
         disablePadding: false,
         label: "Price",
         align: "right",

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -34,13 +34,9 @@ export const detectBestDecimalsDisplay = (price) => {
     if (price !== undefined) {
         // Find out the number of leading floating zeros via regex
         const priceSplit = price.toString().split('.');
-        if (priceSplit.length === 2) {
+        if (priceSplit.length === 2 && priceSplit[0] === '0') {
             const leadingZeros = priceSplit[1].match(/^0+/);
-            decimals += leadingZeros ? leadingZeros[0].length + 1 : 0;
-            if (decimals === 2 && priceSplit[0] === '0') {
-                // Add one more decimal in case of 0.12 kind of price
-                decimals++;
-            }
+            decimals += leadingZeros ? leadingZeros[0].length + 1 : 1;
         }
     }
     return decimals;
@@ -53,6 +49,13 @@ export const formateNumberPriceDecimals = (price, decimals = 2) => {
             currency: 'USD',
             minimumFractionDigits: decimals
         }).format(price)
+}
+
+export const formateNumberPriceDecimalsAuto = (price) => {
+    return formateNumberPriceDecimals(
+        price,
+        detectBestDecimalsDisplay(price),
+    );
 }
 
 export const formateNumberDecimals = (price, decimals = 2) => {


### PR DESCRIPTION
Following [PR #18](https://github.com/osmosis-labs/osmosis-info/pull/18)

**This PR is a follow-up upgrade on the assets price display:**
- Improve auto decimal detection helper
- Implement the detection to the tokens list
- Implement the detection to the pool details display since it had the same issue as the token details display

**To test this PR:**
- Visit the home page and check all assets price display (decimals should make sense regarding the asset $ price)
- Visit a pool page such as [LUM/OSMO](https://info.osmosis.zone/pool/608) and check that exchange rate make sense regarding the swap price
